### PR TITLE
Fix(GeoFencing): Resolve fatal errors in product form plugin

### DIFF
--- a/GeoFencing/Plugin/Product/AddGeoFencingDataToProvider.php
+++ b/GeoFencing/Plugin/Product/AddGeoFencingDataToProvider.php
@@ -36,13 +36,11 @@ class AddGeoFencingDataToProvider
             return $result;
         }
 
-        $product = $subject->getCurrentProduct();
-        $key = $product ? $product->getId() : null;
-
-        // If key is null, it's a new product. The data provider uses an empty string for the key.
-        if ($key === null) {
-            $key = '';
+        if (empty($result)) {
+            return $result;
         }
+        // The key of the result array is the product ID for existing products, or an empty string for new products.
+        $key = array_key_first($result);
 
         // This logic handles both existing products (keyed by ID) and new products (keyed by '').
         if (isset($result[$key])) {


### PR DESCRIPTION
This commit resolves multiple fatal errors in the AddGeoFencingDataToProvider plugin that prevented the admin "Add Product" page from loading.

The following issues were fixed:
1. A "class not found" error was fixed by moving the plugin file to a directory that matches its PSR-4 namespace.
2. An "undefined method" error for `getCurrentProduct()` was fixed by refactoring the plugin to derive the product key from the data provider's result array.
3. The plugin logic was corrected to inject the API key into the proper location within the data structure.