### PR TITLE
fix: Geocode product and pincode locations and refactor logic

### DIFF
--- a/GeoFencing/Helper/Data.php
+++ b/GeoFencing/Helper/Data.php
@@ -12,16 +12,27 @@ namespace AgriCart\GeoFencing\Helper;
 
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\HTTP\Client\Curl;
+use Psr\Log\LoggerInterface;
+use Magento\Framework\App\Helper\Context;
 
 class Data extends AbstractHelper
 {
     const XML_PATH_GEOFENCING = 'geofencing/';
 
-    /**
-     * @param string $field
-     * @param int|null $storeId
-     * @return mixed
-     */
+    protected $curl;
+    protected $logger;
+
+    public function __construct(
+        Context $context,
+        Curl $curl,
+        LoggerInterface $logger
+    ) {
+        $this->curl = $curl;
+        $this->logger = $logger;
+        parent::__construct($context);
+    }
+
     public function getConfigValue($field, $storeId = null)
     {
         return $this->scopeConfig->getValue(
@@ -31,39 +42,64 @@ class Data extends AbstractHelper
         );
     }
 
-    /**
-     * @param int|null $storeId
-     * @return bool
-     */
     public function isEnabled($storeId = null)
     {
         return (bool)$this->getConfigValue(self::XML_PATH_GEOFENCING . 'general/enable', $storeId);
     }
 
-    /**
-     * @param int|null $storeId
-     * @return string
-     */
     public function getGoogleApiKey($storeId = null)
     {
         return $this->getConfigValue(self::XML_PATH_GEOFENCING . 'general/google_api_key', $storeId);
     }
 
-    /**
-     * @param int|null $storeId
-     * @return bool
-     */
     public function isShowMap($storeId = null)
     {
         return (bool)$this->getConfigValue(self::XML_PATH_GEOFENCING . 'frontend/show_map', $storeId);
     }
 
-    /**
-     * @param int|null $storeId
-     * @return int
-     */
     public function getFenceRadius($storeId = null)
     {
         return (int)$this->getConfigValue(self::XML_PATH_GEOFENCING . 'frontend/fence_radius', $storeId);
+    }
+
+    public function getCoordinatesForLocation($location)
+    {
+        $apiKey = $this->getGoogleApiKey();
+        if (!$apiKey || !$location) {
+            return null;
+        }
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . urlencode($location) . '&key=' . $apiKey;
+
+        try {
+            $this->curl->get($url);
+            $response = json_decode($this->curl->getBody(), true);
+
+            if (isset($response['results'][0]['geometry']['location'])) {
+                return $response['results'][0]['geometry']['location'];
+            }
+        } catch (\Exception $e) {
+            $this->logger->error('GeoFencing: Error fetching coordinates from Google Maps API. ' . $e->getMessage());
+        }
+
+        return null;
+    }
+
+    public function parseLocation($locationString)
+    {
+        $matches = [];
+        if (preg_match('/\\(([^)]+)\\)$/', $locationString, $matches)) {
+            if (isset($matches[1])) {
+                $parts = explode(',', $matches[1]);
+                if (count($parts) === 2) {
+                    $lat = (float)trim($parts[0]);
+                    $lng = (float)trim($parts[1]);
+
+                    if ($lat != 0 && $lng != 0) {
+                        return ['lat' => $lat, 'lng' => $lng];
+                    }
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
This commit fixes two issues with the pincode checker feature:
1. The pincode check failed if the product's location was a name (e.g., "Bangalore") instead of coordinates.
2. The product page map would not display for the same reason.

This is resolved by making the backend logic more robust. Both the pincode check controller and the map ViewModel will now automatically use the Google Geocoding API to find the coordinates for a location if they are not already present in the string.

This commit also refactors the code to move the duplicated location parsing and geocoding logic into the shared `Data.php` helper, making the code cleaner and more maintainable.